### PR TITLE
Update mesos_actor_mailboxes.go

### DIFF
--- a/file/mesos_actor_mailboxes.go
+++ b/file/mesos_actor_mailboxes.go
@@ -6,7 +6,7 @@ func init() {
 	f := bun.FileType{
 		Name:        "processes",
 		ContentType: bun.JSON,
-		Paths:       []string{"5050-__processes__.json", "5051-__processes__.json"},
+		Paths:       []string{"5050\:__processes__.json", "5051\:__processes__.json"},
 		Description: "contains mailbox contents for all actors in the Mesos process on the host.",
 		HostTypes: map[bun.HostType]struct{}{
 			bun.Master: {}, bun.Agent: {}, bun.PublicAgent: {},


### PR DESCRIPTION
When running the latest `bun` on a bundle it errors out with an issue on checking:
`5051-__processes__.json.gz`
The actual filename of this particular file is:
`5051:__processes__.json.gz` so I've suggested the change in the code to:
`5051\:__processes__.json.gz` to properly specify a check to these files.