### PR TITLE
Update mesos_actor_mailboxes.go

### DIFF
--- a/file/mesos_actor_mailboxes.go
+++ b/file/mesos_actor_mailboxes.go
@@ -6,7 +6,7 @@ func init() {
 	f := bun.FileType{
 		Name:        "processes",
 		ContentType: bun.JSON,
-		Paths:       []string{"5050-__processes__.json", "5051-__processes__.json"},
+		Paths:       []string{"5050-__processes__.json", "5051-__processes__.json", "5050:__processes__.json", "5051:__processes__.json"},
 		Description: "contains mailbox contents for all actors in the Mesos process on the host.",
 		HostTypes: map[bun.HostType]struct{}{
 			bun.Master: {}, bun.Agent: {}, bun.PublicAgent: {},


### PR DESCRIPTION
The bundle contains the `processes` files as `:__` instead of `-__`. So I've proposed a change to include this type of filename into the checks.