### PR TITLE
Fixed a typo in the command description

### DIFF
--- a/bun/cmd/check.go
+++ b/bun/cmd/check.go
@@ -70,7 +70,7 @@ func init() {
 
 Specify a subcommand to run a specific check, e.g.` + " `bun check health`." +
 			`
-Or run all the available checks by not spcifying any, i.e.` + " `bun check`.",
+Or run all the available checks by not specifying any, i.e.` + " `bun check`.",
 		PreRun: preRun,
 		Run:    runCheck,
 	}


### PR DESCRIPTION
Changed `spcifying` into `specifying` in the command description.