### PR TITLE
Added additional dmesg-T filename and OOM killer checks

### DIFF
--- a/checks/search_checks_yaml.go
+++ b/checks/search_checks_yaml.go
@@ -9,4 +9,8 @@ const searchChecksYAML = `
   description: Check disk space errors in Exhibitor logs
   fileTypeName: exhibitor-log
   searchString: No space left on device
+- name: oom-detect
+  description: Detect OOM-killer occurrences
+  fileTypeName: dmesg-t
+  searchString: java invoked oom-killer
 `

--- a/filetypes/files_type_yaml.go
+++ b/filetypes/files_type_yaml.go
@@ -216,6 +216,7 @@ const filesYAML = `
   contentType: dmesg
   paths:
   - dmesg_-T.output
+  - dmesg_-T-0.output
   description: ""
   dirTypes:
   - master


### PR DESCRIPTION
Added additional `dmesg-T` filename and OOM killer checks to Bun.
The additional dmesg-T filename is `dmesg_-T-0.output` is added to accompany the already known `dmesg_-T.output` file.