### PR TITLE
dcos-net-errors checker that counts errors on dcos-net logs

### DIFF
--- a/bun/cmd/import.go
+++ b/bun/cmd/import.go
@@ -6,4 +6,5 @@ import (
 	_ "github.com/adyatlov/bun/checks/marathon/deployments"
 	_ "github.com/adyatlov/bun/checks/mesos/actormailboxes"
 	_ "github.com/adyatlov/bun/checks/nodecount"
+	_ "github.com/adyatlov/bun/checks/networking"
 )

--- a/checks/networking/dcos_net_errors.go
+++ b/checks/networking/dcos_net_errors.go
@@ -1,76 +1,77 @@
 package errors
 
 import (
-	"bufio"
-	"fmt"
-	"regexp"
-	"github.com/adyatlov/bun"
+  "bufio"
+  "fmt"
+  "regexp"
+  "github.com/adyatlov/bun"
 )
+
 // http://erlang.org/doc/apps/kernel/logger_chapter.html#log_level
 var errorsRegex = "\\[error\\]|\\[critical\\]|\\[alert\\]|\\[emergency\\]"
 
 func init() {
-	builder := bun.CheckBuilder{
-		Name: "net-errors-checker",
-		Description: "Identify errors on dcos-net logs",
- 		CollectFromMasters:      collect,
-		CollectFromAgents:       collect,
-		CollectFromPublicAgents: collect,
-		Aggregate:               aggregate,
-	}
-	check := builder.Build()
-	bun.RegisterCheck(check)
+  builder := bun.CheckBuilder{
+    Name: "net-errors-checker",
+    Description: "Identify errors in dcos-net logs",
+    CollectFromMasters:      collect,
+    CollectFromAgents:       collect,
+    CollectFromPublicAgents: collect,
+    Aggregate:               aggregate,
+  }
+  check := builder.Build()
+  bun.RegisterCheck(check)
 }
 
 func collect(host bun.Host) (ok bool, details interface{}, err error) {
-	errorMatcher, _ := regexp.Compile(errorsRegex)
+  errorMatcher := regexp.MustCompile(errorsRegex)
   keys := 0
 
-	file, err1 := host.OpenFile("net")
+  file, err := host.OpenFile("net")
 
-	if err1 != nil {
-		ok = false
-		errMsg := fmt.Sprintf("Cant open file %s", err1)
-		fmt.Println(errMsg)
-		return
-	}
-
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-  for scanner.Scan() {
-		line := scanner.Text()
-		if errorMatcher.MatchString(line) {
-			keys++
-		}
+  if err != nil {
+    ok = false
+    errMsg := fmt.Sprintf("Cannot open net file %s", err)
+    fmt.Println(errMsg)
+    return
   }
 
-	details = keys
-	ok = true
-	return
+  defer file.Close()
+
+  scanner := bufio.NewScanner(file)
+  for scanner.Scan() {
+    line := scanner.Text()
+    if errorMatcher.MatchString(line) {
+      keys++
+    }
+  }
+
+  details = keys
+  ok = true
+  return
 }
 
 func aggregate(c *bun.Check, b bun.CheckBuilder) {
-	details := []string{}
-	ok := true
+  details := []string{}
+  ok := true
 
-	c.Summary = fmt.Sprintf("There are no networking errors on dcos-net")
+  c.Summary = fmt.Sprintf("There are no networking errors on dcos-net")
 
-	for _, r := range b.OKs {
-		v := r.Details.(int)
-		if v != 0 {
-			ok = false
-			details = append(details, fmt.Sprintf("%d log lines at %v %v with level error or bellow",
-				v, r.Host.Type, r.Host.IP))
-		}
-	}
+  for _, r := range b.OKs {
+    v := r.Details.(int)
+    if v != 0 {
+      ok = false
+      details = append(details, fmt.Sprintf("%d log lines at %v %v with level error or bellow",
+        v, r.Host.Type, r.Host.IP))
+    }
+  }
 
-	if ok {
-		c.OKs = details
-		c.Summary = "dcos-net logs are OK."
-	} else {
-		c.Problems = details
-		c.Summary = fmt.Sprintf("There are errors on dcos-net logs on %d out of %d nodes.", len(details), len(b.OKs))
-	}
+  if ok {
+    c.OKs = details
+    c.Summary = "dcos-net logs are OK."
+  } else {
+    c.Problems = details
+    c.Summary = fmt.Sprintf("There are errors on dcos-net logs on %d out of %d nodes.", len(details), len(b.OKs))
+  }
 }
 

--- a/checks/networking/dcos_net_errors.go
+++ b/checks/networking/dcos_net_errors.go
@@ -1,0 +1,76 @@
+package errors
+
+import (
+	"bufio"
+	"fmt"
+	"regexp"
+	"github.com/adyatlov/bun"
+)
+// http://erlang.org/doc/apps/kernel/logger_chapter.html#log_level
+var errorsRegex = "\\[error\\]|\\[critical\\]|\\[alert\\]|\\[emergency\\]"
+
+func init() {
+	builder := bun.CheckBuilder{
+		Name: "net-errors-checker",
+		Description: "Identify errors on dcos-net logs",
+ 		CollectFromMasters:      collect,
+		CollectFromAgents:       collect,
+		CollectFromPublicAgents: collect,
+		Aggregate:               aggregate,
+	}
+	check := builder.Build()
+	bun.RegisterCheck(check)
+}
+
+func collect(host bun.Host) (ok bool, details interface{}, err error) {
+	errorMatcher, _ := regexp.Compile(errorsRegex)
+  keys := 0
+
+	file, err1 := host.OpenFile("net")
+
+	if err1 != nil {
+		ok = false
+		errMsg := fmt.Sprintf("Cant open file %s", err1)
+		fmt.Println(errMsg)
+		return
+	}
+
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+  for scanner.Scan() {
+		line := scanner.Text()
+		if errorMatcher.MatchString(line) {
+			keys++
+		}
+  }
+
+	details = keys
+	ok = true
+	return
+}
+
+func aggregate(c *bun.Check, b bun.CheckBuilder) {
+	details := []string{}
+	ok := true
+
+	c.Summary = fmt.Sprintf("There are no networking errors on dcos-net")
+
+	for _, r := range b.OKs {
+		v := r.Details.(int)
+		if v != 0 {
+			ok = false
+			details = append(details, fmt.Sprintf("%d log lines at %v %v with level error or bellow",
+				v, r.Host.Type, r.Host.IP))
+		}
+	}
+
+	if ok {
+		c.OKs = details
+		c.Summary = "dcos-net logs are OK."
+	} else {
+		c.Problems = details
+		c.Summary = fmt.Sprintf("There are errors on dcos-net logs on %d out of %d nodes.", len(details), len(b.OKs))
+	}
+}
+


### PR DESCRIPTION
- Adds a checker that counts errors on dcos-net logs according to the regex: "[error]|[critical]|[alert]|[emergency]"
